### PR TITLE
Add useWindowSize hook

### DIFF
--- a/src/hooks/js/useWindowSize.js
+++ b/src/hooks/js/useWindowSize.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+export const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  const handleResize = () => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+};

--- a/src/hooks/ts/useWindowSize.ts
+++ b/src/hooks/ts/useWindowSize.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react";
+
+type WindowSize = {
+  width: number;
+  height: number;
+};
+
+export const useWindowSize = (): WindowSize => {
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  const handleResize = () => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("resize", handleResize);
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+};


### PR DESCRIPTION
## Description
Task: https://github.com/novajslabs/nova.js/issues/50
> Based on @uvee-dev idea, I'm adding the `useWindowSize` hook.

## Piece of code
```tsx
import { useWindowSize } from "./hooks/ts/useWindowSize.ts";

const App = () => {
  const windowScreen = useWindowSize();

  return (
    <div>
      <p>Height: {windowScreen.height}px</p>
      <p>Width: {windowScreen.width}px</p>
    </div>
  );
};
```