### PR TITLE
Add OutsideClick Hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,17 @@
 import { useBattery } from "./hooks/js/useBattery";
-import { useIsTouchDevice } from "./hooks/js/useIsTouchDevice"
+import { useIsTouchDevice } from "./hooks/js/useIsTouchDevice";
+import { useRef } from "react";
+import { useOutsideClick } from "./hooks/js/useOutsideClick";
 
 function AppJs() {
   const battery = useBattery();
   const isTouchDevice = useIsTouchDevice();
 
+  const testRef = useRef(null);
+  useOutsideClick(testRef, () => console.log("Testing"));
+
   return (
-    <div>
+    <div ref={testRef}>
       <p>Battery level:{battery.level * 100}</p>
       <p>{battery.charging ? "Battery charging" : "Battery not charging"}</p>
 

--- a/src/hooks/js/useOutsideClick.js
+++ b/src/hooks/js/useOutsideClick.js
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+export const useOutsideClick = (ref, fn) => {
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (ref.current && !ref.current.contains(event.target)) {
+        fn();
+      }
+    };
+
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [ref, fn]);
+};

--- a/src/hooks/ts/useOutsideClick.ts
+++ b/src/hooks/ts/useOutsideClick.ts
@@ -1,0 +1,20 @@
+import { useEffect, MutableRefObject } from "react";
+
+export const useOutsideClick = (
+  ref: MutableRefObject<HTMLElement | null>,
+  fn: () => void
+) => {
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        fn();
+      }
+    };
+
+    document.addEventListener("click", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, [ref, fn]);
+};


### PR DESCRIPTION
This pull request introduces a new custom hook called useOutsideClick, which provides a convenient way to detect clicks outside of a specified element. This hook is useful for implementing various UI interactions, such as closing a dropdown menu when a user clicks outside of it.