### PR TITLE
Add usePrevious hook in JavaScript and TypeScript

### DIFF
--- a/src/hooks/js/usePrevious.js
+++ b/src/hooks/js/usePrevious.js
@@ -1,0 +1,21 @@
+/**
+ * usePrevious.js
+ *
+ * The usePrevious is a custom hook that allows a component to keep track of the previous
+ * value of a variable. This is useful when you want to compare the current value of a variable
+ * with its previous value.
+ */
+
+import { useRef } from 'react';
+
+export default function usePrevious(value) {
+    const currentRef = useRef(value);
+    const previousRef = useRef();
+
+    if (currentRef.current !== value) {
+        previousRef.current = currentRef.current;
+        currentRef.current = value;
+    }
+
+    return previousRef.current;
+}

--- a/src/hooks/ts/usePrevious.ts
+++ b/src/hooks/ts/usePrevious.ts
@@ -1,0 +1,21 @@
+/**
+ * usePrevious.ts
+ *
+ * The usePrevious is a custom hook that allows a component to keep track of the previous
+ * value of a variable. This is useful when you want to compare the current value of a variable
+ * with its previous value.
+ */
+
+import { useRef } from 'react';
+
+export default function usePrevious<T>(value: T): T | undefined {
+  const currentRef = useRef<T>(value);
+  const previousRef = useRef<T>();
+
+  if (currentRef.current !== value) {
+    previousRef.current = currentRef.current;
+    currentRef.current = value;
+  }
+
+  return previousRef.current;
+}


### PR DESCRIPTION
Adding a new custom hook: `usePrevious` this custom hook allows a component to keep tracket the previus value of a variable. This is useful when you want to compare the current value of a variable with its previous value.

```js
 import { useState } from 'react';

 const App = () => {
      const [value, setValue] = useState(0);
      const previousValue = usePrevious(value);
  
      return (
        <button onClick={() => setValue(value + 1)}>
          Current: { value } - Previous: { previousValue }
        </button>
      )
 }

```

```jsx
- Initial rendering button text: Current 0 - Previous
- First click button text: Current 1 - Previous 0
- Second click button text: Current 2 - Previous 1
```