### PR TITLE
Add useEventListener hook in JavaScript and TypeScript

### DIFF
--- a/src/hooks/js/useEventListener.js
+++ b/src/hooks/js/useEventListener.js
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from "react";
+
+export default function useEventListener(eventName, callback, element = window) {
+    const callbackRef = useRef(callback);
+
+    useEffect(() => {
+        callbackRef.current = callback;
+    }, [callback]);
+
+    useEffect(() => {
+        if (!(element && element.addEventListener)) {
+            return;
+        }
+
+        const handler = (e) => callbackRef.current(e);
+
+        element.addEventListener(eventName, handler);
+
+        return () => {
+            element.removeEventListener(eventName, handler);
+        };
+    }, [eventName, element]);
+}

--- a/src/hooks/ts/useEventListener.ts
+++ b/src/hooks/ts/useEventListener.ts
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+export default function useEventListener(
+  eventName: string,
+  callback: EventListener,
+  element: HTMLElement | (Window & typeof globalThis) | Document | null = window
+) {
+  const callbackRef = useRef<EventListener>(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!(element && element.addEventListener)) {
+      return;
+    }
+
+    const eventListener = (event: Event) => callbackRef.current(event);
+
+    element.addEventListener(eventName, eventListener);
+
+    return () => {
+      element.removeEventListener(eventName, eventListener);
+    };
+  }, [eventName, element]);
+}


### PR DESCRIPTION
This is a custom React hook that allows a component to add an event listener to a specific DOM element and execute a callback function when the event occurs.

## Usage:

```jsx
import { useRef, useState } from 'react';
import useEventListenerTs from './hooks/ts/useEventListener';
import useEventListenerJs from './hooks/js/useEventListener';

const App = () => {
  const [onClick, setOnClick] = useState(0);
  const [documentClick, setDocumentClick] = useState(0);
  const buttonRef = useRef<HTMLButtonElement | null>(null);

  useEventListenerTs(
    'click',
    (e) => {
      e.preventDefault();
      e.stopPropagation();
      setOnClick(onClick + 1);
    },
    buttonRef.current
  );

  useEventListenerJs('click', () => {
    setDocumentClick(documentClick + 1);
  });

  return (
    <>
      <button ref={buttonRef} onClick={() => setOnClick(onClick + 1)}>
        Clicked {onClick} times
      </button>

      <div style={{ marginTop: '1rem' }}>
        Document clicked {documentClick} times
      </div>
    </>
  );
};

export default App;
```

## Demo
https://github.com/novajslabs/nova.js/assets/12173976/d07bd80d-d518-4a4e-8268-b7c5193bdb52


